### PR TITLE
Remove PluginKaetzchen section from katzenpost.toml.sample

### DIFF
--- a/server/katzenpost.toml.sample
+++ b/server/katzenpost.toml.sample
@@ -70,14 +70,6 @@
     Endpoint = "+keyserver"
     Disable = false
 
-  # Here's an example external Kaetzchen service plugin config
-  [[Provider.PluginKaetzchen]]
-    Capability = "echo"
-    Endpoint = "+echo"
-    Disable = false
-    Command = "/var/lib/katzenpost/plugins/echo"
-    MaxConcurrency = 3
-
   # UserDB is the user database configuration.  If left empty the simple
   # BoltDB backed user database will be used with the default database.
   # [Provider.UserDB]


### PR DESCRIPTION
This prevents `server` from running as these keys can't be decoded to `Config`.
This seems to come from another branch and isn't implemented on master.